### PR TITLE
Fixed some minor graphical things

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Complete URLs to uploaded files in the same order as the input files, separated 
 
 **Example output:**
 ```txt
-'https://example.com/foobar.jpg\nhttps://example.com/qweasd.txt'
+https://example.com/foobar.jpg\nhttps://example.com/qweasd.txt
 ```
 
 #### text:
@@ -31,7 +31,7 @@ Complete URLs to uploaded files in the same order as input files. Each line ends
 
 **Example output:**
 ```txt
-'https://example.com/foobar.jpg\nhttps://example.com/qweasd.txt\n'
+https://example.com/foobar.jpg\nhttps://example.com/qweasd.txt\n
 ```
 Protip: if you include input names of uploaded files, how do you handle e.g. newlines in filenames?
 
@@ -42,33 +42,31 @@ A HTML page containing links to uploaded files. Can be anything and is primarily
 
 **Example output:**
 ```html
-'<a href="https://example.com/foobar.jpg">https://example.com/foobar.jpg</a><br /><a href="https://example.com/qweasd.txt">https://example.com/qweasd.txt</a><br />'
+<a href="https://example.com/foobar.jpg">https://example.com/foobar.jpg</a><br /><a href="https://example.com/qweasd.txt">https://example.com/qweasd.txt</a><br />
 ```
 
 #### json:
 **Content-Type:** application/json
 
 **Schema:**
-```json
+```javascript
 {
 	"success": bool /* true if everything is okay, false if there was an error */,
 		"errorcode": int /* only if success=false, the HTTP error code */,
 		"description": string /* only if success=false, the error message */,
-		"files": [
-		{
+		"files": [{
 			"name": string /* original filename sent by the client */,
 			"url": string /* the complete URL to the uploaded file */,
 			"hash": string /* the SHA-1 hash of the uploaded file */,
 			"size": int /* the bytesize of the uploaded file */
-		}
-		] /* only if success=true, info about uploaded files in the same order they were uploaded */
+		}, ...] /* only if success=true, info about uploaded files in the same order they were uploaded */
 }
 ```
 Clients *must not* assume a specific ordering of keys in objects nor any presence/absence of whitespace (outside strings); regex is not a good way to parse this.
 
 **Example output:**
 ```json 
-'{"success": true, "files": [{"name": "cat.jpg", "url": "https://example.com/foobar.jpg", "hash": "8d26e24aabb26c02b5c9a9e102308af2a3597a49", "size": 44294}, {"name": "file.txt", "url": "https://example.com/qweasd.txt", "hash": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "size": 0}]}' 
+{"success": true, "files": [{"name": "cat.jpg", "url": "https://example.com/foobar.jpg", "hash": "8d26e24aabb26c02b5c9a9e102308af2a3597a49", "size": 44294}, {"name": "file.txt", "url": "https://example.com/qweasd.txt", "hash": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "size": 0}]}
 ``` 
 
 #### csv:
@@ -82,7 +80,7 @@ Headers are written on the first line.
 
 **Example output:**
 ```csv
-'name,url,hash,size\ncat.jpg,https://example.com/foobar.jpg,8d26e24aabb26c02b5c9a9e102308af2a3597a49,44294\nfile.txt,https://example.com/qweasd.txt,da39a3ee5e6b4b0d3255bfef95601890afd80709,0\n'
+name,url,hash,size\ncat.jpg,https://example.com/foobar.jpg,8d26e24aabb26c02b5c9a9e102308af2a3597a49,44294\nfile.txt,https://example.com/qweasd.txt,da39a3ee5e6b4b0d3255bfef95601890afd80709,0\n
 ```
 
 ## Rationale:


### PR DESCRIPTION
Removed single-quote (``'``s) from the beginnings and ends of the examples, as I'm fairly sure people can tell what is the example and what isn't by what is inside the code blocks..

I also fixed the JSON schema rendering by having it render as if it was JavaScript instead of JSON. JavaScript's object syntax is very similar yet much more forgiving than JSON's, and since JavaScript allows comments (specifically ``/*`` and ``*/``), it seemed like the best choice.